### PR TITLE
Fix Time Since and Early Trigger

### DIFF
--- a/Current Season.gd
+++ b/Current Season.gd
@@ -13,7 +13,7 @@ const left = " day(s) left in the season"
 func _ready():
 	$Time/Start.text = timeUtils.convert_time(start)
 	$Time/End.text = timeUtils.convert_time(end)
-	var days = floor(timeUtils.get_time_since(end)/86400.0)
+	var days = floor(timeUtils.get_time_until(end)/86400.0)
 	$Days.text = str(days) + left
 	update_candles()
 	var candles = days*(6 if $Pass/Check.button_pressed else 5)
@@ -30,7 +30,7 @@ func _ready():
 		if not $Pass/Check.button_pressed: $Complete.text += "(Note: This does not include season pass items.)"
 
 func _process(_delta):
-	if not $Days.text == str(floor(timeUtils.get_time_since(end)/86400.0)) + left:
+	if not $Days.text == str(floor(timeUtils.get_time_until(end)/86400.0)) + left:
 		_ready()
 
 func _on_check_toggled(_button_pressed):

--- a/Days.gd
+++ b/Days.gd
@@ -36,7 +36,7 @@ const rows = {"Days of Fortune":[["days/fortune/2;56;c","days/fortune/1;66;c",""
 	["days/feast/9;150;c","base/5C;5;c",""],["days/feast/10;44;k","base/5C;5;c","days/feast/11;19;k"],["","base/teleport;0;0",""]]}
 
 func _ready():
-	if timeUtils.get_time_since(end) < 0:
+	if timeUtils.get_time_until(end) < 0 or timeUtils.get_time_until(start) > 0:
 		for c in get_children(): c.hide()
 		$No.show()
 	else:
@@ -46,12 +46,12 @@ func _ready():
 		$Name.text = day
 		$Time/Start.text = timeUtils.convert_time(start)
 		$Time/End.text = timeUtils.convert_time(end)
-		var days = floor(timeUtils.get_time_since(end)/86400.0)
+		var days = floor(timeUtils.get_time_until(end)/86400.0)
 		$Days.text = str(days) + left
 		$Tree.set_tree(rows[day],short[day])
 
 func _process(_delta):
-	if not $Days.text == str(floor(timeUtils.get_time_since(end)/86400.0)) + left:
+	if timeUtils.get_time_until(end) >= 0 && timeUtils.get_time_until(start) <= 0 && not $Days.text == str(floor(timeUtils.get_time_until(end)/86400.0)) + left:
 		_ready()
 
 func _on_tree_bought(iconValue,press):
@@ -63,16 +63,16 @@ func _on_all_pressed():
 	$Tree.buy_all()
 
 func import():
-	if timeUtils.get_time_since(end) >= 0 && bought.has(day):
+	if timeUtils.get_time_until(end) >= 0 && timeUtils.get_time_until(start) <= 0 && bought.has(day):
 		$Tree.import_bought(bought[day])
 	for c in $"../Past".get_children():
 		if not c.is_node_ready(): await c.ready
-		if c is Label or (timeUtils.get_time_since(end) >= 0 && c.name == day): continue
+		if c is Label or (timeUtils.get_time_until(end) >= 0 && c.name == day): continue
 		if rows.has(c.name): c.get_node("Tree").set_tree(rows[c.name],short[c.name])
 		if bought.has(c.name): c.get_node("Tree").import_bought(bought[c.name])
 
 static func get_location_override() -> String:
-	if timeUtils.get_time_since(end) < 0: return ""
+	if timeUtils.get_time_until(end) < 0 or timeUtils.get_time_until(start) > 0: return ""
 	else: return location
 
 func _on_clear_pressed():

--- a/TimeUtils.gd
+++ b/TimeUtils.gd
@@ -19,7 +19,7 @@ static func convert_time(timestamp) -> String:
 		post = "rd"
 	return ("%02d:%02d"%[dict["hour"],dict["minute"]])+" "+ret+post+", "+str(dict["year"])
 
-static func get_time_since(timestamp) -> int:
+static func get_time_until(timestamp) -> int:
 	return floor(Time.get_unix_time_from_datetime_dict(timestamp) - get_game_offset() - Time.get_unix_time_from_system())
 
 static func get_post(day:String) -> String:


### PR DESCRIPTION
Renames get_time_since utility to get_time_until as that is a more accurate description of the value it's returning. Also add checks to ensure the upcoming event doesn't show before its time.