### PR TITLE
Fix Time Calcs

### DIFF
--- a/Days.gd
+++ b/Days.gd
@@ -67,7 +67,7 @@ func import():
 		$Tree.import_bought(bought[day])
 	for c in $"../Past".get_children():
 		if not c.is_node_ready(): await c.ready
-		if c is Label or (timeUtils.get_time_until(end) >= 0 && c.name == day): continue
+		if c is Label or (timeUtils.get_time_until(end) >= 0 && timeUtils.get_time_until(start) <= 0 && c.name == day): continue
 		if rows.has(c.name): c.get_node("Tree").set_tree(rows[c.name],short[c.name])
 		if bought.has(c.name): c.get_node("Tree").import_bought(bought[c.name])
 


### PR DESCRIPTION
Fixes time calculations to include ensuring we're after the start time of a days event to skip populating a tree.